### PR TITLE
Apply glassmorphism styling to selection controls

### DIFF
--- a/src/components/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup.tsx
@@ -30,10 +30,10 @@ const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
         <button
           key={option.value}
           type="button"
-          className={`px-4 py-2 rounded-full border transition-all duration-300 ${
+          className={`px-4 py-2 rounded-full border backdrop-blur-sm transition-all duration-300 ${
             selectedValues.includes(option.value)
-              ? 'border-blue-500 bg-blue-500 bg-opacity-10 text-blue-700'
-              : 'border-gray-300 hover:border-gray-400 text-gray-700'
+              ? 'bg-white/40 border-white/60 text-gray-900 shadow-lg shadow-blue-500/20'
+              : 'bg-white/20 border-white/30 text-gray-800 hover:bg-white/30 hover:border-white/50'
           }`}
           onClick={() => handleChange(option.value)}
           aria-pressed={selectedValues.includes(option.value)}

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -26,17 +26,17 @@ const RadioGroup: React.FC<RadioGroupProps> = ({
         <div key={option.value} className="flex flex-col items-center">
           <button
             type="button"
-            className={`w-12 h-12 rounded-full border-2 transition-all duration-300 flex items-center justify-center ${
+            className={`w-12 h-12 rounded-full border transition-all duration-300 flex items-center justify-center backdrop-blur-sm ${
               value === option.value
-                ? 'border-blue-500 bg-blue-500 bg-opacity-10'
-                : 'border-gray-300 hover:border-gray-400'
+                ? 'border-white/60 bg-white/30 shadow-lg shadow-blue-500/20'
+                : 'border-white/20 bg-white/10 hover:border-white/40 hover:bg-white/20'
             }`}
             onClick={() => onChange(option.value)}
             aria-checked={value === option.value}
             role="radio"
           >
             {value === option.value && (
-              <div className="w-5 h-5 rounded-full bg-blue-500 animate-scale"></div>
+              <div className="w-5 h-5 rounded-full bg-gradient-to-br from-sky-300 via-blue-400 to-indigo-500 shadow-inner shadow-blue-500/40 animate-scale"></div>
             )}
           </button>
           <label className="mt-2 text-sm text-center">{option.label}</label>

--- a/src/pages/FormPage.tsx
+++ b/src/pages/FormPage.tsx
@@ -305,10 +305,10 @@ const FormPage: React.FC = () => {
           {Array.from({ length: 11 }).map((_, i) => (
             <button
               key={i}
-              className={`w-10 h-10 rounded-full border transition-all duration-300 ${
+              className={`w-10 h-10 rounded-full border backdrop-blur-sm transition-all duration-300 ${
                 formData.recommendation === i
-                  ? 'border-blue-500 bg-blue-500 text-white'
-                  : 'border-gray-300 hover:border-gray-400 text-gray-700'
+                  ? 'border-white/60 bg-white/30 text-gray-900 shadow-lg shadow-blue-500/20'
+                  : 'border-white/20 bg-white/10 text-gray-700 hover:border-white/40 hover:bg-white/20'
               }`}
               onClick={() => updateFormData('recommendation', i)}
             >


### PR DESCRIPTION
## Summary
- restyle the shared radio group with translucent glassmorphism accents and a gradient selection indicator
- update checkbox chips to use frosted backgrounds with selection emphasis via opacity and shadow
- align the NPS button set with the new glass aesthetic for consistent visual feedback

## Testing
- npm run lint *(fails: existing TypeScript ESLint warnings about TS 5.6.3 and lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ea818fe08325860d796a6f24dabe