### PR TITLE
Update orb base color to match reference

### DIFF
--- a/src/pages/FormPage.tsx
+++ b/src/pages/FormPage.tsx
@@ -38,7 +38,7 @@ const FormPage: React.FC = () => {
     if (currentStep === 0) setSubmissionStatus('idle');
   }, [currentStep]);
 
-  const orbBaseColor = '#7A9EBF';
+  const orbBaseColor = '#DCE8FF';
 
   const updateFormData = (field: string, value: any) => {
     setFormData(prev => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## Summary
- update the orb base color constant to align with the refreshed visual reference
- ensure existing gradients and border treatments continue to consume the updated base color value

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d9f53b097c83259830282d3354cc2b