### PR TITLE
Add eco eye bubble component with framer-motion animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.54.0",
         "firebase-admin": "^13.4.0",
+        "framer-motion": "^11.5.5",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -3405,6 +3406,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4402,6 +4430,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.54.0",
     "firebase-admin": "^13.4.0",
+    "framer-motion": "^11.5.5",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/components/EcoBubbleOneEye.tsx
+++ b/src/components/EcoBubbleOneEye.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import EyeBubbleBase, {
+  EyeBubbleToken,
+  MotionConfig,
+} from './EyeBubbleBase';
+
+const ecoBubbleToken: EyeBubbleToken = {
+  backgroundFrom: '#E9FFE3',
+  backgroundTo: '#9CE8B1',
+  outline: 'rgba(52, 129, 78, 0.5)',
+  iris: '#2A7747',
+  irisHighlight: '#5CE596',
+  pupil: '#0E2419',
+  highlight: 'rgba(255, 255, 255, 0.95)',
+  sparkle: 'rgba(255, 255, 255, 0.75)',
+  shadow: 'rgba(92, 229, 150, 0.45)',
+  glossFrom: 'rgba(255, 255, 255, 0.8)',
+  glossTo: 'rgba(255, 255, 255, 0)',
+};
+
+export type EcoBubbleOneEyeProps = Omit<
+  React.ComponentProps<typeof EyeBubbleBase>,
+  'token'
+>;
+
+const EcoBubbleOneEye: React.FC<EcoBubbleOneEyeProps> = ({
+  children,
+  ...rest
+}) => (
+  <MotionConfig
+    transition={{ duration: 1.1, ease: [0.6, 0.01, -0.05, 0.95] }}
+    reducedMotion={{ type: 'user' }}
+  >
+    <EyeBubbleBase token={ecoBubbleToken} {...rest}>
+      {children}
+    </EyeBubbleBase>
+  </MotionConfig>
+);
+
+export default EcoBubbleOneEye;

--- a/src/components/EyeBubbleBase.tsx
+++ b/src/components/EyeBubbleBase.tsx
@@ -1,0 +1,167 @@
+import React, { useId } from 'react';
+import { motion, MotionConfig as FramerMotionConfig } from 'framer-motion';
+
+export type EyeBubbleToken = {
+  /** Outer gradient starting tone */
+  backgroundFrom: string;
+  /** Outer gradient ending tone */
+  backgroundTo: string;
+  /** Outline color used around the bubble */
+  outline: string;
+  /** Base color of the iris */
+  iris: string;
+  /** Highlight colour for the iris gradient */
+  irisHighlight: string;
+  /** Pupil colour */
+  pupil: string;
+  /** Eye highlight colour */
+  highlight: string;
+  /** Sparkle accent colour */
+  sparkle: string;
+  /** Shadow used for drop shadows */
+  shadow: string;
+  /** Gloss gradient starting colour */
+  glossFrom: string;
+  /** Gloss gradient ending colour */
+  glossTo: string;
+};
+
+export interface EyeBubbleBaseProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  token: EyeBubbleToken;
+  size?: number;
+  children?: React.ReactNode;
+}
+
+export const MotionConfig = FramerMotionConfig;
+
+const EyeBubbleBase: React.FC<EyeBubbleBaseProps> = ({
+  token,
+  size = 240,
+  className,
+  style,
+  children,
+  ...rest
+}) => {
+  const gradientId = useId();
+  const glossId = useId();
+  const irisId = useId();
+
+  const containerClassName = [
+    'relative inline-flex items-center justify-center',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const mergedStyle: React.CSSProperties = {
+    width: size,
+    height: size,
+    ...style,
+  };
+
+  return (
+    <div className={containerClassName} style={mergedStyle} {...rest}>
+      <motion.svg
+        width={size}
+        height={size}
+        viewBox="0 0 240 240"
+        role="img"
+        aria-hidden
+        initial={{ rotate: -2 }}
+        animate={{ rotate: [-2, 2, -1.5, 1.5, 0] }}
+        transition={{ duration: 18, repeat: Infinity, ease: 'easeInOut' }}
+      >
+        <defs>
+          <radialGradient id={gradientId} cx="50%" cy="50%" r="70%">
+            <stop offset="0%" stopColor={token.backgroundFrom} />
+            <stop offset="100%" stopColor={token.backgroundTo} />
+          </radialGradient>
+          <linearGradient id={glossId} x1="30%" y1="20%" x2="70%" y2="80%">
+            <stop offset="0%" stopColor={token.glossFrom} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={token.glossTo} stopOpacity="0" />
+          </linearGradient>
+          <radialGradient id={irisId} cx="50%" cy="50%" r="60%">
+            <stop offset="0%" stopColor={token.irisHighlight} />
+            <stop offset="100%" stopColor={token.iris} />
+          </radialGradient>
+        </defs>
+
+        <motion.circle
+          cx="120"
+          cy="120"
+          r="108"
+          fill={`url(#${gradientId})`}
+          stroke={token.outline}
+          strokeWidth="2"
+          style={{ filter: `drop-shadow(0 25px 40px ${token.shadow})` }}
+          initial={{ scale: 0.95, opacity: 0.9 }}
+          animate={{ scale: [0.95, 1, 0.97], opacity: [0.9, 1, 0.95] }}
+          transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.ellipse
+          cx="120"
+          cy="120"
+          rx="54"
+          ry="46"
+          fill={`url(#${irisId})`}
+          stroke={token.outline}
+          strokeWidth="1"
+          initial={{ x: -3 }}
+          animate={{ x: [-3, 4, -5, 3, 0], y: [1, -2, 1.5, -1.5, 0] }}
+          transition={{ duration: 6, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.circle
+          cx="120"
+          cy="120"
+          r="20"
+          fill={token.pupil}
+          initial={{ scale: 0.9 }}
+          animate={{ scale: [0.9, 1.05, 0.95] }}
+          transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.circle
+          cx="108"
+          cy="104"
+          r="8"
+          fill={token.highlight}
+          initial={{ opacity: 0.8 }}
+          animate={{ opacity: [0.8, 1, 0.7] }}
+          transition={{ duration: 3, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.circle
+          cx="140"
+          cy="140"
+          r="6"
+          fill={token.sparkle}
+          initial={{ opacity: 0.5, scale: 0.5 }}
+          animate={{ opacity: [0.5, 0.9, 0.4], scale: [0.5, 0.9, 0.6] }}
+          transition={{ duration: 5, repeat: Infinity, ease: 'easeInOut' }}
+        />
+
+        <motion.path
+          d="M70 90 C 90 70, 150 70, 170 100"
+          fill="none"
+          stroke={`url(#${glossId})`}
+          strokeWidth="12"
+          strokeLinecap="round"
+          initial={{ pathLength: 0.7, opacity: 0.6 }}
+          animate={{ pathLength: [0.7, 1, 0.8], opacity: [0.6, 0.9, 0.5] }}
+          transition={{ duration: 7, repeat: Infinity, ease: 'easeInOut' }}
+        />
+      </motion.svg>
+
+      {children ? (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default EyeBubbleBase;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,6 @@
+export { default as EyeBubbleBase } from './EyeBubbleBase';
+export type { EyeBubbleBaseProps, EyeBubbleToken } from './EyeBubbleBase';
+export { MotionConfig } from './EyeBubbleBase';
+
+export { default as EcoBubbleOneEye } from './EcoBubbleOneEye';
+export type { EcoBubbleOneEyeProps } from './EcoBubbleOneEye';


### PR DESCRIPTION
## Summary
- add the framer-motion dependency to support animated UI elements
- implement the EyeBubbleBase component with token-driven gradients and motion primitives
- add the EcoBubbleOneEye variant and expose the new components via the component index

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dea3b3086883258b83f67538d08d5a